### PR TITLE
Implement custom JSON API types

### DIFF
--- a/include/api/Api.h
+++ b/include/api/Api.h
@@ -2,8 +2,11 @@
 #define API_H
 
 #include <string>
+#include <utility>
 
 #include <boost/json.hpp>
+
+#include "api/types.h"
 
 //constexpr std::string_view kKalshiApiUrl{"https://trading-api.kalshi.com/trade-api/v2"};
 constexpr std::string_view kKalshiApiUrl{"https://demo-api.kalshi.co/trade-api/v2"};
@@ -23,22 +26,54 @@ public:
 
 private:
     // auth
-    static inline std::string member_id;
-    static inline std::string token;
+    static inline LoginResponse login;
 
     // portfolio
-    static inline double balance;
-    //static inline double payout;
+    static inline PortfolioBalanceResponse balance;
 
     // core
     static boost::json::value MakeRequest(std::string_view endpoint, bool doPostMethod = false);
     static boost::json::value MakeRequest(std::string_view endpoint, const boost::json::value &json, bool doPostMethod = false);
 
-    static boost::json::value GetRequest(std::string_view endpoint);
-    static boost::json::value GetRequest(std::string_view endpoint, const boost::json::value &json);
+    static void GetRequest(std::string_view endpoint)
+    {
+        MakeRequest(endpoint);
+    }
 
-    static boost::json::value PostRequest(std::string_view endpoint);
-    static boost::json::value PostRequest(std::string_view endpoint, const boost::json::value &json);
+    template <typename TResponse>
+    static TResponse GetRequest(std::string_view endpoint)
+    {
+        return boost::json::value_to<TResponse>(MakeRequest(endpoint));
+    }
+
+    template <typename TResponse, typename TRequest>
+    static TResponse GetRequest(std::string_view endpoint, TRequest&& req)
+    {
+        boost::json::value jv;
+        boost::json::value_from<TRequest>(std::forward<TRequest>(req), jv);
+
+        return boost::json::value_to<TResponse>(MakeRequest(endpoint, jv));
+    }
+
+    static void PostRequest(std::string_view endpoint)
+    {
+        MakeRequest(endpoint, true);
+    }
+
+    template <typename TResponse>
+    static TResponse PostRequest(std::string_view endpoint)
+    {
+        return boost::json::value_to<TResponse>(MakeRequest(endpoint, true));
+    }
+
+    template <typename TResponse, typename TRequest>
+    static TResponse PostRequest(std::string_view endpoint, TRequest&& req)
+    {
+        boost::json::value jv;
+        boost::json::value_from<TRequest>(std::forward<TRequest>(req), jv);
+
+        return boost::json::value_to<TResponse>(MakeRequest(endpoint, jv, true));
+    }
 };
 
 #endif

--- a/include/api/converters.h
+++ b/include/api/converters.h
@@ -1,0 +1,31 @@
+#ifndef CONVERTERS_H
+#define CONVERTERS_H
+
+#include <boost/json.hpp>
+
+#include "api/types.h"
+
+inline void tag_invoke(const boost::json::value_from_tag &TODO, boost::json::value &jv, const LoginRequest &req)
+{
+    jv = {
+        { "email", req.email },
+        { "password", req.password }
+    };
+}
+
+inline LoginResponse tag_invoke(const boost::json::value_to_tag<LoginResponse> &TODO, const boost::json::value &jv)
+{
+    if (auto jo = jv.if_object())
+    {
+        return LoginResponse{
+            jo->at("member_id").as_string().c_str(),
+            jo->at("token").as_string().c_str()
+        };
+    }
+    else
+    {
+        throw std::runtime_error("Invalid JSON response.");
+    }
+}
+
+#endif

--- a/include/api/converters.h
+++ b/include/api/converters.h
@@ -5,7 +5,7 @@
 
 #include "api/types.h"
 
-inline void tag_invoke(const boost::json::value_from_tag &TODO, boost::json::value &jv, const LoginRequest &req)
+inline void tag_invoke(const boost::json::value_from_tag &, boost::json::value &jv, const LoginRequest &req)
 {
     jv = {
         { "email", req.email },
@@ -13,7 +13,7 @@ inline void tag_invoke(const boost::json::value_from_tag &TODO, boost::json::val
     };
 }
 
-inline LoginResponse tag_invoke(const boost::json::value_to_tag<LoginResponse> &TODO, const boost::json::value &jv)
+inline LoginResponse tag_invoke(const boost::json::value_to_tag<LoginResponse> &, const boost::json::value &jv)
 {
     if (auto jo = jv.if_object())
     {

--- a/include/api/types.h
+++ b/include/api/types.h
@@ -1,0 +1,26 @@
+#ifndef TYPES_H
+#define TYPES_H
+
+#include <string>
+#include <string_view>
+
+struct LoginRequest
+{
+    std::string_view email{};
+    std::string_view password{};
+};
+
+struct LoginResponse
+{
+    std::string member_id{};
+    std::string token{};
+};
+
+struct PortfolioBalanceResponse
+{
+    double balance{};
+    //TODO try using std::optional and null coalescence
+    double payout{};
+};
+
+#endif

--- a/src/api/Api.auth.cpp
+++ b/src/api/Api.auth.cpp
@@ -5,6 +5,8 @@
 #include <boost/json.hpp>
 
 #include "api/Api.h"
+#include "api/types.h"
+#include "api/converters.h"
 
 void Api::Login(std::string_view email, std::string_view password)
 {
@@ -21,22 +23,7 @@ void Api::Login(std::string_view email, std::string_view password)
         throw std::invalid_argument("Password not provided.");
     }
 
-    boost::json::object jsonReq = {
-        { "email", email },
-        { "password", password }
-    };
-
-    boost::json::value jsonRes = PostRequest("/login", jsonReq);
-
-    if (auto jsonObj = jsonRes.if_object())
-    {
-        member_id = jsonObj->at("member_id").as_string();
-        token = jsonObj->at("token").as_string();
-    }
-    else
-    {
-        //TODO throw?
-    }
+    login = PostRequest<LoginResponse, LoginRequest>("/login", LoginRequest{email, password});
 }
 
 void Api::Logout()
@@ -48,6 +35,5 @@ void Api::Logout()
 
     PostRequest("/logout");
 
-    member_id = std::string();
-    token = std::string();
+    login = LoginResponse{};
 }

--- a/src/api/Api.core.cpp
+++ b/src/api/Api.core.cpp
@@ -34,7 +34,7 @@ boost::json::value Api::MakeRequest(std::string_view endpoint, const boost::json
 
         if (IsLoggedIn())
         {
-		    headers.push_back(std::string{"Authorization: Bearer "}.append(token));
+		    headers.push_back(std::string{"Authorization: Bearer "}.append(login.token));
         }
 
         if (doPostMethod)
@@ -90,24 +90,4 @@ boost::json::value Api::MakeRequest(std::string_view endpoint, const boost::json
 
     //TODO do we want to throw an exception here? (note that /logout returns 204, not 200)
     return boost::json::value();
-}
-
-boost::json::value Api::GetRequest(std::string_view endpoint)
-{
-    return MakeRequest(endpoint);
-}
-
-boost::json::value Api::GetRequest(std::string_view endpoint, const boost::json::value &json)
-{
-    return MakeRequest(endpoint, json);
-}
-
-boost::json::value Api::PostRequest(std::string_view endpoint)
-{
-    return MakeRequest(endpoint, true);
-}
-
-boost::json::value Api::PostRequest(std::string_view endpoint, const boost::json::value &json)
-{
-    return MakeRequest(endpoint, json, true);
 }

--- a/src/api/Api.helpers.cpp
+++ b/src/api/Api.helpers.cpp
@@ -2,5 +2,5 @@
 
 bool Api::IsLoggedIn()
 {
-    return !member_id.empty();
+    return !login.member_id.empty();
 }

--- a/src/api/Api.portfolio.cpp
+++ b/src/api/Api.portfolio.cpp
@@ -5,6 +5,8 @@
 #include <boost/json.hpp>
 
 #include "api/Api.h"
+#include "api/types.h"
+#include "api/converters.h"
 
 double Api::GetBalance()
 {
@@ -13,17 +15,7 @@ double Api::GetBalance()
         throw std::logic_error("Not logged in.");
     }
 
-    boost::json::value jsonRes = GetRequest("/portfolio/balance");
+    balance = GetRequest<PortfolioBalanceResponse>("/portfolio/balance");
 
-    if (auto jsonObj = jsonRes.if_object())
-    {
-        balance = jsonObj->at("balance").as_int64() / 100.0;
-        //payout = jsonObj->at("payout").as_int64() / 100.0;
-    }
-    else
-    {
-        //TODO throw?
-    }
-
-    return balance;
+    return balance.balance;
 }


### PR DESCRIPTION
The Boost JSON library supports custom types. For the most part, we still have to manually convert object members, but this helps to separate concerns.