### PR TITLE
Implement custom events

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,6 +24,11 @@
                     // escape spaces in any parent folder names (and let shell expand wildcard)
                     "quoting": "escape"
                 },
+                {
+                    "value": "${workspaceFolder}/src/util/*.cpp",
+                    // escape spaces in any parent folder names (and let shell expand wildcard)
+                    "quoting": "escape"
+                },
                 "-o",
                 {
                     "value": "${workspaceFolder}/build/kdeck.out",

--- a/include/ui/MainFrame.h
+++ b/include/ui/MainFrame.h
@@ -26,8 +26,7 @@ private:
     void Update();
 
     // event handlers
-    void OnLogin(wxCommandEvent& event);
-    void OnLogout(wxCommandEvent& event);
+    void OnLoginOrLogout(wxCommandEvent& event);
     void OnApiError(wxCommandEvent& event);
     void OnLogoutMenuItemSelected(wxCommandEvent& event);
     void OnAbout(wxCommandEvent& event);

--- a/include/ui/MainFrame.h
+++ b/include/ui/MainFrame.h
@@ -6,7 +6,7 @@
 
 enum
 {
-    ID_Login = wxID_HIGHEST + 1,
+    //ID_Login = wxID_HIGHEST + 1,
     ID_Logout = wxID_HIGHEST + 2,
 };
 
@@ -26,7 +26,8 @@ private:
     void Update();
 
     // event handlers
-    void OnLoginButtonClicked(wxCommandEvent& event);
+    void OnLogin(wxCommandEvent& event);
+    void OnLogout(wxCommandEvent& event);
     void OnLogoutMenuItemSelected(wxCommandEvent& event);
     void OnAbout(wxCommandEvent& event);
     void OnExit(wxCommandEvent& event);

--- a/include/ui/MainFrame.h
+++ b/include/ui/MainFrame.h
@@ -28,6 +28,7 @@ private:
     // event handlers
     void OnLogin(wxCommandEvent& event);
     void OnLogout(wxCommandEvent& event);
+    void OnApiError(wxCommandEvent& event);
     void OnLogoutMenuItemSelected(wxCommandEvent& event);
     void OnAbout(wxCommandEvent& event);
     void OnExit(wxCommandEvent& event);

--- a/include/util/event.h
+++ b/include/util/event.h
@@ -5,5 +5,6 @@
 
 wxDECLARE_EVENT(EVT_LOGIN, wxCommandEvent);
 wxDECLARE_EVENT(EVT_LOGOUT, wxCommandEvent);
+wxDECLARE_EVENT(EVT_API_ERROR, wxCommandEvent);
 
 #endif

--- a/include/util/event.h
+++ b/include/util/event.h
@@ -1,0 +1,9 @@
+#ifndef EVENT_H
+#define EVENT_H
+
+#include <wx/wx.h>
+
+wxDECLARE_EVENT(EVT_LOGIN, wxCommandEvent);
+wxDECLARE_EVENT(EVT_LOGOUT, wxCommandEvent);
+
+#endif

--- a/src/ui/BalancePanel.cpp
+++ b/src/ui/BalancePanel.cpp
@@ -6,6 +6,7 @@
 #include "ui/EventPositionPanel.h"
 #include "ui/MarketPositionPanel.h"
 #include "api/Api.h"
+#include "util/event.h"
 
 // constructor ////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
@@ -42,13 +43,15 @@ void BalancePanel::Update()
     {
         lblBalanceAmount->SetLabelText(std::to_string(Api::GetBalance()));
     }
-    catch (std::logic_error &e)
+    catch (std::exception &e)
     {
-        wxLogError(e.what());
-    }
-    catch (std::runtime_error &e)
-    {
-        wxLogError("Unknown error.");
-        wxLogDebug(e.what());
+        std::cerr << e.what() << std::endl;
+
+        wxCommandEvent* event = new wxCommandEvent(EVT_API_ERROR);
+        event->SetString("Balance update failed!");
+
+        event->SetEventObject(this);
+
+        QueueEvent(event);
     }
 }

--- a/src/ui/LoginPanel.cpp
+++ b/src/ui/LoginPanel.cpp
@@ -5,6 +5,7 @@
 #include "ui/LoginPanel.h"
 #include "ui/MainFrame.h"
 #include "api/Api.h"
+#include "util/event.h"
 
 // constructor ////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
@@ -26,7 +27,7 @@ void LoginPanel::Setup()
     txtEmail = new wxTextCtrl(this, wxID_ANY);
     txtPassword = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PASSWORD);
 
-    wxButton* btnLogin = new wxButton(this, ID_Login, "Login");
+    wxButton* btnLogin = new wxButton(this, wxID_ANY, "Login");
     btnLogin->Bind(wxEVT_BUTTON, &LoginPanel::OnLoginButtonClicked, this);
 
     wxBoxSizer* boxSizer = new wxBoxSizer(wxVERTICAL);
@@ -52,10 +53,11 @@ void LoginPanel::OnLoginButtonClicked(wxCommandEvent &event)
     {
         Api::Login(txtEmail->GetValue().ToStdString(), txtPassword->GetValue().ToStdString());
 
-        wxLogStatus("Login succeeded!");
+        wxCommandEvent* event = new wxCommandEvent(EVT_LOGIN);
 
-        // allow MainFrame to detect login status change
-        event.Skip();
+        event->SetEventObject(this);
+
+        QueueEvent(event);
     }
     catch (std::invalid_argument &e)
     {

--- a/src/ui/LoginPanel.cpp
+++ b/src/ui/LoginPanel.cpp
@@ -49,33 +49,24 @@ void LoginPanel::Setup()
 
 void LoginPanel::OnLoginButtonClicked(wxCommandEvent &event)
 {
+    wxCommandEvent* loginEvent = nullptr;
+
     try
     {
         Api::Login(txtEmail->GetValue().ToStdString(), txtPassword->GetValue().ToStdString());
 
-        wxCommandEvent* event = new wxCommandEvent(EVT_LOGIN);
-
-        event->SetEventObject(this);
-
-        QueueEvent(event);
+        loginEvent = new wxCommandEvent(EVT_LOGIN);
+        loginEvent->SetString("Login succeeded!");
     }
-    catch (std::invalid_argument &e)
+    catch (std::exception &e)
     {
-        wxLogError(e.what());
+        std::cerr << e.what() << std::endl;
 
-        wxLogStatus("Login failed!");
+        loginEvent = new wxCommandEvent(EVT_API_ERROR);
+        loginEvent->SetString("Login failed!");
     }
-    catch (std::logic_error &e)
-    {
-        wxLogError(e.what());
 
-        wxLogStatus("Login failed!");
-    }
-    catch (std::runtime_error &e)
-    {
-        wxLogError("Unknown error.");
-        wxLogDebug(e.what());
+    loginEvent->SetEventObject(this);
 
-        wxLogStatus("Login failed!");
-    }
+    QueueEvent(loginEvent);
 }

--- a/src/ui/MainFrame.cpp
+++ b/src/ui/MainFrame.cpp
@@ -5,6 +5,7 @@
 #include "ui/LoginPanel.h"
 #include "ui/PortfolioPanel.h"
 #include "api/Api.h"
+#include "util/event.h"
 
 // constructor ////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
@@ -15,7 +16,8 @@ MainFrame::MainFrame()
     Setup();
     Update();
 
-    Bind(wxEVT_BUTTON, &MainFrame::OnLoginButtonClicked, this, ID_Login);
+    Bind(EVT_LOGIN, &MainFrame::OnLogin, this);
+    Bind(EVT_LOGOUT, &MainFrame::OnLogout, this);
     Bind(wxEVT_MENU, &MainFrame::OnLogoutMenuItemSelected, this, ID_Logout);
     Bind(wxEVT_MENU, &MainFrame::OnAbout, this, wxID_ABOUT);
     Bind(wxEVT_MENU, &MainFrame::OnExit, this, wxID_EXIT);
@@ -78,10 +80,18 @@ void MainFrame::Update()
 // event handlers /////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 
-//TODO this should be implemented as a custom event
-void MainFrame::OnLoginButtonClicked(wxCommandEvent &event)
+void MainFrame::OnLogin(wxCommandEvent &event)
 {
     Update();
+
+    wxLogStatus("Login succeeded!");
+}
+
+void MainFrame::OnLogout(wxCommandEvent &event)
+{
+    Update();
+
+    wxLogStatus("Logout succeeded!");
 }
 
 void MainFrame::OnLogoutMenuItemSelected(wxCommandEvent &event)
@@ -94,7 +104,11 @@ void MainFrame::OnLogoutMenuItemSelected(wxCommandEvent &event)
         {
             Api::Logout();
 
-            wxLogStatus("Logout succeeded!");
+            wxCommandEvent* event = new wxCommandEvent(EVT_LOGOUT);
+
+            event->SetEventObject(this);
+
+            QueueEvent(event);
         }
         catch (std::logic_error &e)
         {
@@ -109,8 +123,6 @@ void MainFrame::OnLogoutMenuItemSelected(wxCommandEvent &event)
 
             wxLogStatus("Logout failed!");
         }
-
-        Update();
     }
 }
 

--- a/src/ui/MainFrame.cpp
+++ b/src/ui/MainFrame.cpp
@@ -16,8 +16,8 @@ MainFrame::MainFrame()
     Setup();
     Update();
 
-    Bind(EVT_LOGIN, &MainFrame::OnLogin, this);
-    Bind(EVT_LOGOUT, &MainFrame::OnLogout, this);
+    Bind(EVT_LOGIN, &MainFrame::OnLoginOrLogout, this);
+    Bind(EVT_LOGOUT, &MainFrame::OnLoginOrLogout, this);
     Bind(EVT_API_ERROR, &MainFrame::OnApiError, this);
     Bind(wxEVT_MENU, &MainFrame::OnLogoutMenuItemSelected, this, ID_Logout);
     Bind(wxEVT_MENU, &MainFrame::OnAbout, this, wxID_ABOUT);
@@ -82,14 +82,7 @@ void MainFrame::Update()
 // event handlers /////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 
-void MainFrame::OnLogin(wxCommandEvent &event)
-{
-    Update();
-
-    wxLogStatus(event.GetString());
-}
-
-void MainFrame::OnLogout(wxCommandEvent &event)
+void MainFrame::OnLoginOrLogout(wxCommandEvent &event)
 {
     Update();
 

--- a/src/ui/PortfolioPanel.cpp
+++ b/src/ui/PortfolioPanel.cpp
@@ -6,6 +6,7 @@
 #include "ui/EventPositionPanel.h"
 #include "ui/MarketPositionPanel.h"
 #include "api/Api.h"
+#include "util/event.h"
 
 // constructor ////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
@@ -64,17 +65,15 @@ void PortfolioPanel::Update()
 
         wxLogStatus("Portfolio update succeeded!");
     }
-    catch (std::logic_error &e)
+    catch (std::exception &e)
     {
-        wxLogError(e.what());
+        std::cerr << e.what() << std::endl;
 
-        wxLogStatus("Portfolio update failed!");
-    }
-    catch (std::runtime_error &e)
-    {
-        wxLogError("Unknown error.");
-        wxLogDebug(e.what());
+        wxCommandEvent* event = new wxCommandEvent(EVT_API_ERROR);
+        event->SetString("Portfolio update failed!");
 
-        wxLogStatus("Portfolio update failed!");
+        event->SetEventObject(this);
+
+        QueueEvent(event);
     }
 }

--- a/src/util/event.cpp
+++ b/src/util/event.cpp
@@ -1,0 +1,4 @@
+#include "util/event.h"
+
+wxDEFINE_EVENT(EVT_LOGIN, wxCommandEvent);
+wxDEFINE_EVENT(EVT_LOGOUT, wxCommandEvent);

--- a/src/util/event.cpp
+++ b/src/util/event.cpp
@@ -2,3 +2,4 @@
 
 wxDEFINE_EVENT(EVT_LOGIN, wxCommandEvent);
 wxDEFINE_EVENT(EVT_LOGOUT, wxCommandEvent);
+wxDEFINE_EVENT(EVT_API_ERROR, wxCommandEvent);


### PR DESCRIPTION
wxWidgets provides a facility for making custom event types. In the simplest case, one need not provide a derived class.

This change implements the simple case to define login/logout and API error types. Currently, these are used to signify app state changes and to propagate to MainFrame for consistent messaging to the user.

The existing exception handling code was simplified because it was mostly duplicate handling of state violations.