### PR TITLE
Enable scrollbar for portfolio positions

### DIFF
--- a/include/ui/BalancePanel.h
+++ b/include/ui/BalancePanel.h
@@ -8,7 +8,7 @@ class BalancePanel : public wxPanel
 public:
     BalancePanel(wxWindow* parent, wxWindowID winid = wxID_ANY);
 
-    void Update();
+    void UpdateStuff();
 
 private:
     wxStaticText* lblBalanceAmount;

--- a/include/ui/MainFrame.h
+++ b/include/ui/MainFrame.h
@@ -23,7 +23,7 @@ private:
 
     // init
     void Setup();
-    void Update();
+    void UpdateStuff();
 
     // event handlers
     void OnLoginOrLogout(wxCommandEvent& event);

--- a/include/ui/PortfolioPanel.h
+++ b/include/ui/PortfolioPanel.h
@@ -16,7 +16,7 @@ private:
 
     // init
     void Setup();
-    void Update();
+    void UpdateStuff();
 };
 
 #endif

--- a/include/ui/PortfolioPanel.h
+++ b/include/ui/PortfolioPanel.h
@@ -5,7 +5,7 @@
 
 #include "ui/BalancePanel.h"
 
-class PortfolioPanel : public wxPanel
+class PortfolioPanel : public wxScrolledWindow
 {
 public:
     PortfolioPanel(wxWindow* parent, wxWindowID winid = wxID_ANY);

--- a/src/ui/BalancePanel.cpp
+++ b/src/ui/BalancePanel.cpp
@@ -15,7 +15,7 @@ BalancePanel::BalancePanel(wxWindow* parent, wxWindowID winid)
     : wxPanel(parent, winid)
 {
     Setup();
-    Update();
+    UpdateStuff();
 }
 
 // init ///////////////////////////////////////////////////////////////////////
@@ -37,7 +37,7 @@ void BalancePanel::Setup()
     SetSizer(boxSizer);
 }
 
-void BalancePanel::Update()
+void BalancePanel::UpdateStuff()
 {
     try
     {

--- a/src/ui/MainFrame.cpp
+++ b/src/ui/MainFrame.cpp
@@ -14,7 +14,7 @@ MainFrame::MainFrame()
     : wxFrame(nullptr, wxID_ANY, "kdeck")
 {
     Setup();
-    Update();
+    UpdateStuff();
 
     Bind(EVT_LOGIN, &MainFrame::OnLoginOrLogout, this);
     Bind(EVT_LOGOUT, &MainFrame::OnLoginOrLogout, this);
@@ -52,7 +52,7 @@ void MainFrame::Setup()
     SetStatusText("Welcome to kdeck!");
 }
 
-void MainFrame::Update()
+void MainFrame::UpdateStuff()
 {
     //TODO is this removing the status bar?
     DestroyChildren();
@@ -84,7 +84,7 @@ void MainFrame::Update()
 
 void MainFrame::OnLoginOrLogout(wxCommandEvent &event)
 {
-    Update();
+    UpdateStuff();
 
     wxLogStatus(event.GetString());
 }

--- a/src/ui/PortfolioPanel.cpp
+++ b/src/ui/PortfolioPanel.cpp
@@ -12,7 +12,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 PortfolioPanel::PortfolioPanel(wxWindow* parent, wxWindowID winid)
-    : wxPanel(parent, winid)
+    : wxScrolledWindow(parent, winid)
 {
     Setup();
     Update();
@@ -35,6 +35,7 @@ void PortfolioPanel::Setup()
     boxSizer->Add(pnlPositions, flagsPnl);
 
     SetSizer(boxSizer);
+    SetScrollRate(10, 10);
 }
 
 void PortfolioPanel::Update()

--- a/src/ui/PortfolioPanel.cpp
+++ b/src/ui/PortfolioPanel.cpp
@@ -15,7 +15,7 @@ PortfolioPanel::PortfolioPanel(wxWindow* parent, wxWindowID winid)
     : wxScrolledWindow(parent, winid)
 {
     Setup();
-    Update();
+    UpdateStuff();
 }
 
 // init ///////////////////////////////////////////////////////////////////////
@@ -38,11 +38,11 @@ void PortfolioPanel::Setup()
     SetScrollRate(10, 10);
 }
 
-void PortfolioPanel::Update()
+void PortfolioPanel::UpdateStuff()
 {
     try
     {
-        pnlBalance->Update();
+        pnlBalance->UpdateStuff();
 
         Api::GetPositions();
 


### PR DESCRIPTION
A user may have a large number of positions, so we must enable scrollbars.

During this implementation, it was discovered that we were shadowing the base wxWindow::Update() method because scrolling was very slow. We renamed all custom widgets' Update() methods to UpdateStuff(). This is temporary as it is expected update logic will have to change as we add more API calls.