### PR TITLE
Set some project config options in CMake

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "C_Cpp.debugShortcut": false
+    "C_Cpp.debugShortcut": false,
+    "files.associations": {
+        "*.hpp.in": "cpp"
+    },
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,6 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${FullOutputDir}/static_libs")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${FullOutputDir}")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${FullOutputDir}")
 
-#TODO move installDir from CMakePresets.json to here?
-
 #TODO it is recommended to use CI tools to enforce warnings limits
 # target_compile_options(${PROJECT_NAME}
 #     PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,4 +29,8 @@ configure_file(
     "${CMAKE_BINARY_DIR}/include/config.hpp"
 )
 
+#TODO GitHub Copilot suggested this to combine source and generated headers
+# install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+# install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,4 +24,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${FullOutputDir}")
 #         "-fdiagnostics-color=always"
 # )
 
+configure_file(
+    "${CMAKE_SOURCE_DIR}/include/config.hpp.in"
+    "${CMAKE_BINARY_DIR}/include/config.hpp"
+)
+
 add_subdirectory(src)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,7 +24,11 @@
             "description": "Using compilers: C = /usr/bin/gcc, CXX = /usr/bin/g++",
             "inherits": "default",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "KALSHI_API_URL": {
+                    "type": "string",
+                    "value": "https://demo-api.kalshi.co/trade-api/v2"
+                }
             }
         },
         {
@@ -33,7 +37,11 @@
             "description": "Using compilers: C = /usr/bin/gcc, CXX = /usr/bin/g++",
             "inherits": "default",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
+                "CMAKE_BUILD_TYPE": "Release",
+                "KALSHI_API_URL": {
+                    "type": "string",
+                    "value": "https://trading-api.kalshi.com/trade-api/v2"
+                }
             }
         }
     ]

--- a/include/api/Api.hpp
+++ b/include/api/Api.hpp
@@ -6,10 +6,8 @@
 
 #include <boost/json.hpp>
 
+#include "config.hpp"
 #include "api/types.hpp"
-
-//constexpr std::string_view kKalshiApiUrl{"https://trading-api.kalshi.com/trade-api/v2"};
-constexpr std::string_view kKalshiApiUrl{"https://demo-api.kalshi.co/trade-api/v2"};
 
 template <typename TResponse>
 using ApiResult = std::variant<TResponse, ErrorResponse>;

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -1,0 +1,12 @@
+// NOTE: This file only exists to prevent IDE errors. However, it
+//       may interfere with the build process. If you encounter
+//       any issues, please ensure that CMake's generated
+//       config.hpp file is looked up *first*, i.e.
+//
+//           ${CMAKE_BINARY_DIR}/include
+//
+//       before
+//
+//           ${CMAKE_SOURCE_DIR}/include
+
+#include "config.hpp.in"

--- a/include/config.hpp.in
+++ b/include/config.hpp.in
@@ -1,0 +1,8 @@
+#ifndef CONFIG_HPP
+#define CONFIG_HPP
+
+// NOTE: These are set in CMakePresets.json
+
+constexpr std::string_view kKalshiApiUrl{"@KALSHI_API_URL@"};
+
+#endif

--- a/include/config.hpp.in
+++ b/include/config.hpp.in
@@ -1,7 +1,12 @@
 #ifndef CONFIG_HPP
 #define CONFIG_HPP
 
-// NOTE: These are set in CMakePresets.json
+#include <string_view>
+
+// NOTE: These are set by CMake. Also see CMakePresets.json.
+
+constexpr std::string_view kProjectName{"@CMAKE_PROJECT_NAME@"};
+constexpr std::string_view kProjectVersion{"@CMAKE_PROJECT_VERSION@"};
 
 constexpr std::string_view kKalshiApiUrl{"@KALSHI_API_URL@"};
 

--- a/include/ui/MainFrame.hpp
+++ b/include/ui/MainFrame.hpp
@@ -4,6 +4,8 @@
 #include <wx/wx.h>
 #include <curlpp/cURLpp.hpp>
 
+#include "config.hpp"
+
 class PortfolioPanel;
 
 enum
@@ -15,7 +17,7 @@ enum
 class MainFrame : public wxFrame
 {
 public:
-    MainFrame(wxWindow* parent = nullptr, wxWindowID winid = wxID_ANY, const wxString &title = "kdeck");
+    MainFrame(wxWindow* parent = nullptr, wxWindowID winid = wxID_ANY, const wxString &title = std::string{kProjectName});
 
     void UpdateStuff();
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,8 +5,9 @@ add_executable(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
-    PRIVATE
-        "${CMAKE_SOURCE_DIR}/include"
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
 )
 
 # see https://cmake.org/cmake/help/latest/module/FindwxWidgets.html

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -6,8 +6,9 @@ add_library(${PROJECT_NAME} STATIC
 )
 
 target_include_directories(${PROJECT_NAME}
-    PRIVATE
-        "${CMAKE_SOURCE_DIR}/include"
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
 )
 
 # see https://cmake.org/cmake/help/latest/module/FindBoost.html

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -13,8 +13,9 @@ add_library(${PROJECT_NAME} STATIC
 )
 
 target_include_directories(${PROJECT_NAME}
-    PRIVATE
-        "${CMAKE_SOURCE_DIR}/include"
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
 )
 
 # see https://cmake.org/cmake/help/latest/module/FindwxWidgets.html

--- a/src/ui/MainFrame.cpp
+++ b/src/ui/MainFrame.cpp
@@ -1,6 +1,9 @@
 #include <algorithm>
+
+#include <boost/format.hpp>
 #include <wx/wx.h>
 
+#include "config.hpp"
 #include "api/Api.hpp"
 #include "ui/MainFrame.hpp"
 #include "ui/LoginDialog.hpp"
@@ -51,7 +54,7 @@ void MainFrame::Setup()
     ///////////////////////////////////////////////////////////////////////////
 
     CreateStatusBar(3);
-    ShowStatus("Welcome to kdeck!");
+    ShowStatus((boost::format("Welcome to %1%!") % kProjectName).str());
 
     ///////////////////////////////////////////////////////////////////////////
 
@@ -184,7 +187,7 @@ void MainFrame::OnMenuItemSelected(wxCommandEvent &event)
 
             break;
         case wxID_ABOUT:
-            wxMessageBox("This is kdeck", "About kdeck", wxOK | wxICON_INFORMATION);
+            wxMessageBox((boost::format("%1% v%2%") % kProjectName % kProjectVersion).str(), (boost::format("About %1%") % kProjectName).str(), wxOK | wxICON_INFORMATION);
 
             break;
         case wxID_EXIT:


### PR DESCRIPTION
For build configuration variables, it is ideal to have a single source of truth. So for project name, project version, and API URL, we let CMake handle these and propagate their values to a source file.