### PR TITLE
Fix GitHub build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,8 +3,6 @@
 #**/.classpath
 **/.dockerignore
 **/.env
-**/.git
-**/.gitignore
 **/.github
 #**/.project
 #**/.settings
@@ -21,8 +19,23 @@
 **/Dockerfile*
 #**/node_modules
 #**/npm-debug.log
+
+# we need to copy the repo to the container because
+# vcpkg leans on git for managing port versions
+#**/.git
+#**/.gitignore
+
+# we bind-mount these to get build output and to take
+# advantage of vcpkg binary caching on the host
 build/
-vendor/
+vcpkg_installed/
+
+# these directories can be immense in size and should be
+# superseded by a bind-mounted binary cache (vcpkg_installed/)
+vendor/microsoft/vcpkg/buildtrees/
+vendor/microsoft/vcpkg/downloads/
+vendor/microsoft/vcpkg/packages/
+
 CMakeUserPresets.json
 LICENSE.md
 README.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,37 +42,37 @@ jobs:
           && ./bootstrap-vcpkg.sh \
           && ./vcpkg install
 
-      # - name: Build Docker image
-      #   run: docker build -t kdeck-build .
+      - name: Build Docker image
+        run: docker build -t kdeck-build .
 
-      # # NOTE: We use a bind-mount instead of a volume for the build dir
-      # #       because the runner user will not have permission to access
-      # #       an (automatically created) anonymous volume.
+      # NOTE: We use a bind-mount instead of a volume for the build dir
+      #       because the runner user will not have permission to access
+      #       an (automatically created) anonymous volume.
 
-      # - name: Run build in Docker container
-      #   run: |
-      #     docker run
-      #       -v "${{ github.workspace }}/build:/src/build"
-      #       -v "${{ github.workspace }}/vendor:/src/vendor"
-      #       -v "${{ github.workspace }}/vcpkg_installed:/src/vcpkg_installed"
-      #       kdeck-build
+      - name: Run build in Docker container
+        run: |
+          docker run
+            -v "${{ github.workspace }}/build:/src/build"
+            -v "${{ github.workspace }}/vendor:/src/vendor"
+            -v "${{ github.workspace }}/vcpkg_installed:/src/vcpkg_installed"
+            kdeck-build
 
-      # - name: Record hash
-      #   run: echo ${{ github.sha }} > release.txt
+      - name: Record hash
+        run: echo ${{ github.sha }} > release.txt
 
-      # - name: Create tarball
-      #   run: |
-      #     tar -czvf "kdeck-Linux64-${{ github.ref_name }}.tar.gz" \
-      #       --directory="${{ github.workspace }}" \
-      #         release.txt \
-      #         LICENSE.md \
-      #       --directory="${{ github.workspace }}/build/bin/Linux64/Release" \
-      #         kdeck
+      - name: Create tarball
+        run: |
+          tar -czvf "kdeck-Linux64-${{ github.ref_name }}.tar.gz" \
+            --directory="${{ github.workspace }}" \
+              release.txt \
+              LICENSE.md \
+            --directory="${{ github.workspace }}/build/bin/Linux64/Release" \
+              kdeck
 
-      # - name: Release
-      #   uses: softprops/action-gh-release@v2
-      #   with:
-      #     prerelease: true
-      #     fail_on_unmatched_files: true
-      #     files: |
-      #       kdeck-Linux64-${{ github.ref_name }}.tar.gz
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: true
+          fail_on_unmatched_files: true
+          files: |
+            kdeck-Linux64-${{ github.ref_name }}.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       contents: write
     steps:
       - name: Maximize build space
-        uses: sergiomorenolopez/remove-unwanted-software@3ccb44bee98b5232ab087e2bb23a5d8b14043223
+        uses: AdityaGarg8/remove-unwanted-software@e2a42bc9a15f8414a9078f38b702de2a2976733d # tag `v3`
         with:
           remove-android: 'true'
           remove-cached-tools: 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,18 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Maximize build space
+        uses: sergiomorenolopez/remove-unwanted-software@3ccb44bee98b5232ab087e2bb23a5d8b14043223
+        with:
+          remove-android: 'true'
+          remove-cached-tools: 'true'
+          remove-codeql: 'true'
+          #remove-docker-images: 'true'
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-large-packages: 'true'
+          #remove-swapfile: 'true'
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,16 +32,6 @@ jobs:
           key: vcpkg-${{ runner.os }}-${{ hashFiles('**/vcpkg.json') }}
           path: vcpkg_installed
 
-      # NOTE: Our .dockerignore doesn't copy git repo metadata,
-      #       so vcpkg will be unable to install dependencies
-      #       inside the container.
-
-      - name: Install vcpkg dependencies
-        run: |
-          cd "${{ github.workspace }}/vendor/microsoft/vcpkg" \
-          && ./bootstrap-vcpkg.sh \
-          && ./vcpkg install
-
       - name: Build Docker image
         run: docker build -t kdeck-build .
 
@@ -53,7 +43,6 @@ jobs:
         run: |
           docker run
             -v "${{ github.workspace }}/build:/src/build"
-            -v "${{ github.workspace }}/vendor:/src/vendor"
             -v "${{ github.workspace }}/vcpkg_installed:/src/vcpkg_installed"
             kdeck-build
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,9 +41,9 @@ jobs:
 
       - name: Run build in Docker container
         run: |
-          docker run
-            -v "${{ github.workspace }}/build:/src/build"
-            -v "${{ github.workspace }}/vcpkg_installed:/src/vcpkg_installed"
+          docker run \
+            -v "${{ github.workspace }}/build:/src/build" \
+            -v "${{ github.workspace }}/vcpkg_installed:/src/vcpkg_installed" \
             kdeck-build
 
       - name: Record hash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,22 @@
 FROM debian:bookworm-slim
 
-# NOTE: This is not a minimal set of dependencies. However, because
-#       different vcpkg packages expect various build tools to be
-#       present, it was easier to install them as secondary dependencies
-#       of their Debian counterparts.
+# NOTE: vcpkg packages expect various build tools to be present.
+#       The *-dev packages especially pull in many additional
+#       dependencies.
 
 RUN apt-get update && apt-get -y --no-install-suggests install \
-    autoconf \
     automake \
     bison \
-    build-essential \
     ca-certificates \
     cmake \
     curl \
     g++ \
     git \
     make \
-    libdbus-1-dev \
-    libegl1-mesa-dev \
-    libgles2-mesa-dev \
     libgtk-3-dev \
-    libibus-1.0-dev \
-    libsystemd-dev \
     libtool \
-    libwayland-dev \
     libwxgtk3.2-dev \
-    libx11-dev \
-    libxext-dev \
-    libxft-dev \
-    libxi-dev \
-    libxkbcommon-dev \
-    libxtst-dev \
-    linux-libc-dev \
-    pkg-config \
     python3 \
-    python3-babel \
     python3-jinja2 \
     unzip \
     zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,22 @@ RUN apt-get update && apt-get -y --no-install-suggests install \
 WORKDIR /src
 COPY . /src
 
+# not necessary if this has been performed on the host, but just in case
+RUN ["git", "submodule", "update", "--init", "--recursive"]
+
+# bootstrap vcpkg (download the vcpkg executable itself)
+RUN ["./vendor/microsoft/vcpkg/bootstrap-vcpkg.sh"]
+
 # NOTE: We have to run the configure step and the build step together
 #       because /src/build is bind-mounted to the host machine, and that
 #       needs to occur before the configure step is run or else the
 #       files are obscured. Therefore, we have to use the shell form
 #       rather than the exec form.
 
+SHELL ["/bin/bash", "-c"]
+
 #TODO it's not clear why we need CMAKE_MAKE_PROGRAM; this is supposed to be detected automatically
-CMD cmake -DCMAKE_MAKE_PROGRAM=make --preset release && cmake --build --preset release
+
+CMD ./vendor/microsoft/vcpkg/vcpkg install \
+    && cmake -DCMAKE_MAKE_PROGRAM=make --preset release \
+    && cmake --build --preset release

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,16 +50,10 @@ RUN ["git", "submodule", "update", "--init", "--recursive"]
 # bootstrap vcpkg (download the vcpkg executable itself)
 RUN ["./vendor/microsoft/vcpkg/bootstrap-vcpkg.sh"]
 
-# NOTE: We have to run the configure step and the build step together
-#       because /src/build is bind-mounted to the host machine, and that
-#       needs to occur before the configure step is run or else the
-#       files are obscured. Therefore, we have to use the shell form
-#       rather than the exec form.
-
 SHELL ["/bin/bash", "-c"]
 
-#TODO it's not clear why we need CMAKE_MAKE_PROGRAM; this is supposed to be detected automatically
-
+#TODO it's not clear why we need CMAKE_MAKE_PROGRAM; this is supposed to be detected automatically;
+#     is it because the shell form of RUN doesn't capture environment variables? (a new shell is invoked)
 CMD ./vendor/microsoft/vcpkg/vcpkg install \
     && cmake -DCMAKE_MAKE_PROGRAM=make --preset release \
     && cmake --build --preset release


### PR DESCRIPTION
This fixes the GitHub build by moving vcpkg initialization and dependency installation to the container.

A cache is configured to carry over vcpkg's binary cache between runs, but it doesn't seem to be working.