### PR TITLE
Make app version configurable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,9 +76,19 @@ jobs:
               kdeck
 
       - name: Release
+        if: ${{ github.ref_type == 'tag' }}
         uses: softprops/action-gh-release@v2
         with:
           prerelease: true
           fail_on_unmatched_files: true
           files: |
             kdeck-Linux64-${{ github.ref_name }}.tar.gz
+
+      - name: Upload artifact
+        if: ${{ github.ref_type != 'tag' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact
+          compression-level: 0
+          if-no-files-found: error
+          path: kdeck-Linux64-${{ github.ref_name }}.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,6 @@ name: Debian Bookworm Release
 
 on:
   push:
-    # this won't work as the build requires a tag with a version number
     # branches:
     #   - main
     tags:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,11 @@ jobs:
           save-always: true
 
       - name: Build Docker image
+        if: ${{ github.ref_type == 'tag' }}
+        run: docker build -t kdeck-build -DAPP_VERSION=${{ github.ref_name }} .
+
+      - name: Build Docker image
+        if: ${{ github.ref_type != 'tag' }}
         run: docker build -t kdeck-build .
 
       # NOTE: We use a bind-mount instead of a volume for the build dir

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,12 +44,7 @@ jobs:
           path: build/vcpkg_installed
           save-always: true
 
-      - name: Build Docker image (with version)
-        if: ${{ github.ref_type == 'tag' }}
-        run: docker build -t kdeck-build -DAPP_VERSION=${{ github.ref_name }} .
-
-      - name: Build Docker image (without version)
-        if: ${{ github.ref_type != 'tag' }}
+      - name: Build Docker image
         run: docker build -t kdeck-build .
 
       # NOTE: We use a bind-mount instead of a volume for the build dir
@@ -60,6 +55,7 @@ jobs:
         run: |
           docker run \
             -v "${{ github.workspace }}/build:/src/build" \
+            ${{ github.ref_type == 'tag' && format('--env {0}', github.ref_name) || '' }} \
             kdeck-build
 
       - name: Record hash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,11 +45,11 @@ jobs:
           path: build/vcpkg_installed
           save-always: true
 
-      - name: Build Docker image
+      - name: Build Docker image (with version)
         if: ${{ github.ref_type == 'tag' }}
         run: docker build -t kdeck-build -DAPP_VERSION=${{ github.ref_name }} .
 
-      - name: Build Docker image
+      - name: Build Docker image (without version)
         if: ${{ github.ref_type != 'tag' }}
         run: docker build -t kdeck-build .
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,10 @@ on:
     # branches:
     #   - main
     tags:
-      - "v*.*.*"
+      # NOTE: The tag name must conform to CMake's `project` command spec:
+      #       See: https://cmake.org/cmake/help/latest/command/project.html#options
+
+      - "[0-9]+.[0-9]+.[0-9]+"
 
   workflow_dispatch:
     # allows manual execution of the workflow

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,14 @@ jobs:
             --directory="${{ github.workspace }}/build/bin/Linux64/Release" \
               kdeck
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact
+          compression-level: 0
+          if-no-files-found: error
+          path: kdeck-Linux64-${{ github.ref_name }}.tar.gz
+
       - name: Release
         if: ${{ github.ref_type == 'tag' }}
         uses: softprops/action-gh-release@v2
@@ -83,12 +91,3 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             kdeck-Linux64-${{ github.ref_name }}.tar.gz
-
-      - name: Upload artifact
-        if: ${{ github.ref_type != 'tag' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifact
-          compression-level: 0
-          if-no-files-found: error
-          path: kdeck-Linux64-${{ github.ref_name }}.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ github.ref_type == 'tag' }}
         uses: softprops/action-gh-release@v2
         with:
-          prerelease: true
+          prerelease: ${{ github.ref_name != 'main' }}
           fail_on_unmatched_files: true
           files: |
             kdeck-Linux64-${{ github.ref_name }}.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.20.0)
-project(kdeck VERSION 0.2.0 LANGUAGES CXX)
+
+set(APP_VERSION "0.0.0" CACHE STRING "Application version")
+
+project(kdeck VERSION ${APP_VERSION} LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bookworm-slim
 
+ARG APP_VERSION="0.0.0"
+
 # NOTE: vcpkg packages expect various build tools to be present.
 #       The *-dev packages especially pull in many additional
 #       dependencies.
@@ -36,5 +38,5 @@ SHELL ["/bin/bash", "-c"]
 
 #TODO it's not clear why we need CMAKE_MAKE_PROGRAM; this is supposed to be detected automatically;
 #     is it because the shell form of RUN doesn't capture environment variables? (a new shell is invoked)
-CMD cmake -DCMAKE_MAKE_PROGRAM=make --preset release \
+CMD cmake -DCMAKE_MAKE_PROGRAM=make -DAPP_VERSION="$APP_VERSION" --preset release \
     && cmake --build --preset release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:bookworm-slim
-
 ARG APP_VERSION="0.0.0"
+
+FROM debian:bookworm-slim
 
 # NOTE: vcpkg packages expect various build tools to be present.
 #       The *-dev packages especially pull in many additional
@@ -36,7 +36,10 @@ RUN ["./vendor/microsoft/vcpkg/bootstrap-vcpkg.sh"]
 
 SHELL ["/bin/bash", "-c"]
 
+ARG APP_VERSION
+ENV APP_VERSION=${APP_VERSION}
+
 #TODO it's not clear why we need CMAKE_MAKE_PROGRAM; this is supposed to be detected automatically;
 #     is it because the shell form of RUN doesn't capture environment variables? (a new shell is invoked)
-CMD cmake -DCMAKE_MAKE_PROGRAM=make -DAPP_VERSION="$APP_VERSION" --preset release \
+CMD cmake -DCMAKE_MAKE_PROGRAM=make -D APP_VERSION="${APP_VERSION}" --preset release \
     && cmake --build --preset release

--- a/src/ui/MainFrame.cpp
+++ b/src/ui/MainFrame.cpp
@@ -260,7 +260,7 @@ namespace kdeck
 
                 break;
             case wxID_ABOUT:
-                wxMessageBox(wxString::Format("%s v%s", kProjectName, kProjectVersion), wxString::Format("About %s", kProjectName), wxOK | wxICON_INFORMATION);
+                wxMessageBox(wxString::Format("%s %s", kProjectName, kProjectVersion), wxString::Format("About %s", kProjectName), wxOK | wxICON_INFORMATION);
 
                 break;
             case wxID_EXIT:


### PR DESCRIPTION
This makes the app version configurable from any build path. It will default to "0.0.0" to signify a local dev build. The GitHub workflow is automated to pass the git tag name to the build. Tagged versions must now no longer include the "v" prefix (as they must conform to CMake's project comamnd spec.